### PR TITLE
Optimizations and style improvements for Rect branch

### DIFF
--- a/arcade/types/numbers.py
+++ b/arcade/types/numbers.py
@@ -1,0 +1,15 @@
+"""Prevents import issues.
+
+If an :py:mod:`arcade.types` submodule attempts to run
+``from arcade.types import AsFloat``, it could cause issues with
+circular imports or partially initialized modules.
+"""
+from __future__ import annotations
+
+from typing import Union
+
+#: 1. Makes pyright happier while also telling readers
+#: 2. Tells readers we're converting any ints to floats
+AsFloat = Union[float, int]
+
+__all__ = ['AsFloat']

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -314,7 +314,7 @@ class Rect(NamedTuple):
         return repr(self)
 
 
-# Convinience constructors
+# Shorthand creation helpers
 
 def LRBT(left: AsFloat, right: AsFloat, bottom: AsFloat, top: AsFloat) -> Rect:
     width = right - left

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -366,7 +366,7 @@ def Viewport(left: int, bottom: int, width: int, height: int) -> Rect:
     return Rect(left, right, bottom, top, width, height, x, y)
 
 
-def Kwargtangle(**kwargs: AsFloat) -> Rect:
+def Kwargtangle(**kwargs: AsFloat | None) -> Rect:
 
     # Perform iteration only once and store it as a set literal
     specified: set[str] = {k for k, v in kwargs.items() if v is not None}

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 from typing import NamedTuple, Optional, TypedDict
+
+
 from pyglet.math import Vec2
 
-from arcade.types import AsFloat
+from arcade.types.numbers import AsFloat
+from arcade.types.vector_like import AnchorPoint
+
 from arcade.utils import ReplacementWarning, warning
 
 RectParams = tuple[AsFloat, AsFloat, AsFloat, AsFloat]
@@ -21,19 +25,6 @@ class RectKwargs(TypedDict):
     height: float
     x: float
     y: float
-
-
-class AnchorPoint:
-    """Provides helper aliases for several Vec2s to be used as anchor points in UV space."""
-    BOTTOM_LEFT = Vec2(0.0, 0.0)
-    BOTTOM_CENTER = Vec2(0.5, 0.0)
-    BOTTOM_RIGHT = Vec2(1.0, 0.0)
-    CENTER_LEFT = Vec2(0.0, 0.5)
-    CENTER = Vec2(0.5, 0.5)
-    CENTER_RIGHT = Vec2(1.0, 0.5)
-    TOP_LEFT = Vec2(0.0, 1.0)
-    TOP_CENTER = Vec2(0.5, 1.0)
-    TOP_RIGHT = Vec2(1.0, 1.0)
 
 
 class Rect(NamedTuple):

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -306,12 +306,8 @@ class Rect(NamedTuple):
                 "width": self.width,
                 "height": self.height}
 
-    # def __repr__(self) -> str:
-    #     return (
-    #         f"<{self.__class__.__name__} "
-    #         f"left={self.left} right={self.right} "
-    #     )
-
+    # Since __repr__ is handled automatically by NamedTuple, we focus on
+    # human-readable spot-check values for __str__ instead.
     def __str__(self) -> str:
         return (
             f"<{self.__class__.__name__} LRBT({self.left}, {self.right}, {self.bottom}, {self.top})"

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -306,12 +306,17 @@ class Rect(NamedTuple):
                 "width": self.width,
                 "height": self.height}
 
-    def __repr__(self) -> str:
-        return (f"<{self.__class__.__name__} LRBT({self.left}, {self.right}, {self.bottom}, {self.top})"
-                f" XYWH({self.x}, {self.y}, {self.width}, {self.height})>")
+    # def __repr__(self) -> str:
+    #     return (
+    #         f"<{self.__class__.__name__} "
+    #         f"left={self.left} right={self.right} "
+    #     )
 
     def __str__(self) -> str:
-        return repr(self)
+        return (
+            f"<{self.__class__.__name__} LRBT({self.left}, {self.right}, {self.bottom}, {self.top})"
+            f" XYWH({self.x}, {self.y}, {self.width}, {self.height})>")
+
 
 
 # Shorthand creation helpers

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -264,11 +264,15 @@ class Rect(NamedTuple):
         return (self.left < point.x < self.right) and (self.bottom < point.y < self.top)
 
     def to_points(self) -> tuple[Vec2, Vec2, Vec2, Vec2]:
+        left = self.left
+        bottom = self.bottom
+        right = self.right
+        top = self.top
         return (
-            Vec2(self.left, self.bottom),
-            Vec2(self.left, self.top),
-            Vec2(self.right, self.top),
-            Vec2(self.right, self.bottom)
+            Vec2(left, bottom),
+            Vec2(left, top),
+            Vec2(right, top),
+            Vec2(right, bottom)
         )
 
     @property

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -367,14 +367,22 @@ def Viewport(left: int, bottom: int, width: int, height: int) -> Rect:
 
 
 def Kwargtangle(**kwargs: AsFloat) -> Rect:
+
+    # Perform iteration only once and store it as a set literal
+    specified: set[str] = {k for k, v in kwargs.items() if v is not None}
+    have_lb = 'left' in specified and 'bottom' in specified
+
     # LRBT
-    if all(kwargs.get(v, None) is not None for v in ["left", "right", "top", "bottom"]):
+    if have_lb and 'top' in specified and 'right' in specified:
         return LRBT(kwargs["left"], kwargs["right"], kwargs["bottom"], kwargs["top"])
+
     # LBWH
-    elif all(kwargs.get(v, None) is not None for v in ["left", "bottom", "width", "height"]):
+    have_wh = 'width' in specified and 'height' in specified
+    if have_wh and have_lb:
         return LBWH(kwargs["left"], kwargs["bottom"], kwargs["width"], kwargs["height"])
+
     # XYWH
-    elif all(kwargs.get(v, None) is not None for v in ["x", "y", "width", "height"]):
+    if have_wh and 'x' in specified and 'y' in specified:
         return XYWH(kwargs["x"], kwargs["y"], kwargs["width"], kwargs["height"])
-    else:
-        raise ValueError("Not enough attributes defined for a valid rectangle!")
+
+    raise ValueError("Not enough attributes defined for a valid rectangle!")

--- a/arcade/types/rect.py
+++ b/arcade/types/rect.py
@@ -307,7 +307,7 @@ class Rect(NamedTuple):
                 "height": self.height}
 
     def __repr__(self) -> str:
-        return (f"<Rect LRBT({self.left}, {self.right}, {self.bottom}, {self.top})"
+        return (f"<{self.__class__.__name__} LRBT({self.left}, {self.right}, {self.bottom}, {self.top})"
                 f" XYWH({self.x}, {self.y}, {self.width}, {self.height})>")
 
     def __str__(self) -> str:

--- a/arcade/types/vector_like.py
+++ b/arcade/types/vector_like.py
@@ -1,0 +1,25 @@
+"""This will hold point, size, and other similar aliases.
+
+This is a submodule of :py:mod:`arcade.types` to avoid issues with:
+
+* Circular imports
+* Partially initialized modules
+
+"""
+from __future__ import annotations
+
+
+from pyglet.math import Vec2
+
+
+class AnchorPoint:
+    """Provides helper aliases for several Vec2s to be used as anchor points in UV space."""
+    BOTTOM_LEFT = Vec2(0.0, 0.0)
+    BOTTOM_CENTER = Vec2(0.5, 0.0)
+    BOTTOM_RIGHT = Vec2(1.0, 0.0)
+    CENTER_LEFT = Vec2(0.0, 0.5)
+    CENTER = Vec2(0.5, 0.5)
+    CENTER_RIGHT = Vec2(1.0, 0.5)
+    TOP_LEFT = Vec2(0.0, 1.0)
+    TOP_CENTER = Vec2(0.5, 1.0)
+    TOP_RIGHT = Vec2(1.0, 1.0)

--- a/tests/unit/rect/test_rect_creation_helpers.py
+++ b/tests/unit/rect/test_rect_creation_helpers.py
@@ -3,7 +3,55 @@ from __future__ import annotations
 
 import pytest
 
-from arcade.types.rect import Kwargtangle
+from arcade.types.rect import LBWH, LRBT, XYWH, XYRR, Kwargtangle
+
+
+def test_make_LBWH():
+    r = LBWH(10, 10, 10, 10)
+    assert r.left == 10.0
+    assert r.bottom == 10.0
+    assert r.width == 10.0
+    assert r.height == 10.0
+    assert r.top == 20.0
+    assert r.right == 20.0
+    assert r.x == 15.0
+    assert r.y == 15.0
+
+
+def test_make_LRBT():
+    r = LRBT(10, 20, 10, 20)
+    assert r.left == 10.0
+    assert r.bottom == 10.0
+    assert r.width == 10.0
+    assert r.height == 10.0
+    assert r.top == 20.0
+    assert r.right == 20.0
+    assert r.x == 15.0
+    assert r.y == 15.0
+
+
+def test_make_XYWH():
+    r = XYWH(15, 15, 10, 10)
+    assert r.left == 10.0
+    assert r.bottom == 10.0
+    assert r.width == 10.0
+    assert r.height == 10.0
+    assert r.top == 20.0
+    assert r.right == 20.0
+    assert r.x == 15.0
+    assert r.y == 15.0
+
+
+def test_make_XYRR():
+    r = XYRR(15, 15, 5, 5)
+    assert r.left == 10.0
+    assert r.bottom == 10.0
+    assert r.width == 10.0
+    assert r.height == 10.0
+    assert r.top == 20.0
+    assert r.right == 20.0
+    assert r.x == 15.0
+    assert r.y == 15.0
 
 
 def test_kwargtangle_missing_args():
@@ -91,3 +139,4 @@ def test_kwargtangle_none_args():
 
     with pytest.raises(ValueError):
         _ = Kwargtangle(x=0, y=None, width=0, height=0)
+

--- a/tests/unit/rect/test_rect_creation_helpers.py
+++ b/tests/unit/rect/test_rect_creation_helpers.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+
+import pytest
+
+from arcade.types.rect import Kwargtangle
+
+
+def test_kwargtangle_missing_args():
+    # Zero args raises ValueError
+    with pytest.raises(ValueError):
+        _ = Kwargtangle()
+
+    # LRBT
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, right=0, bottom=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, right=0, top=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, top=0, bottom=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(right=0, top=0, bottom=0)
+
+    # LBWH
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, bottom=0, width=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, bottom=0, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, width=0, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(bottom=0, width=0, height=0)
+
+    # XYWH
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(x=0, y=0, width=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(x=0, y=0, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(y=0, width=0, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(x=0, width=0, height=0)
+
+
+def test_kwargtangle_none_args():
+
+    # LRBT
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, right=0, bottom=0, top=None)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, right=0, bottom=None, top=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, right=None, top=0, bottom=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left = None, right=0, top=0, bottom=0)
+
+    # LBWH
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, bottom=0, width=0, height=None)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, bottom=0, width=None, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=0, botto=None, width=0, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(left=None, bottom=0, width=0, height=0)
+
+    # XYWH
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(x=0, y=0, width=0, height=None)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(x=0, y=0, width=None, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(x=None, y=0, width=0, height=0)
+
+    with pytest.raises(ValueError):
+        _ = Kwargtangle(x=0, y=None, width=0, height=0)

--- a/tests/unit/rect/test_rect_instances.py
+++ b/tests/unit/rect/test_rect_instances.py
@@ -16,54 +16,6 @@ def test_attributes():
     assert A_RECT.y == 15.0
 
 
-def test_make_LBWH():
-    r = LBWH(10, 10, 10, 10)
-    assert r.left == 10.0
-    assert r.bottom == 10.0
-    assert r.width == 10.0
-    assert r.height == 10.0
-    assert r.top == 20.0
-    assert r.right == 20.0
-    assert r.x == 15.0
-    assert r.y == 15.0
-
-
-def test_make_LRBT():
-    r = LRBT(10, 20, 10, 20)
-    assert r.left == 10.0
-    assert r.bottom == 10.0
-    assert r.width == 10.0
-    assert r.height == 10.0
-    assert r.top == 20.0
-    assert r.right == 20.0
-    assert r.x == 15.0
-    assert r.y == 15.0
-
-
-def test_make_XYWH():
-    r = XYWH(15, 15, 10, 10)
-    assert r.left == 10.0
-    assert r.bottom == 10.0
-    assert r.width == 10.0
-    assert r.height == 10.0
-    assert r.top == 20.0
-    assert r.right == 20.0
-    assert r.x == 15.0
-    assert r.y == 15.0
-
-
-def test_make_XYRR():
-    r = XYRR(15, 15, 5, 5)
-    assert r.left == 10.0
-    assert r.bottom == 10.0
-    assert r.width == 10.0
-    assert r.height == 10.0
-    assert r.top == 20.0
-    assert r.right == 20.0
-    assert r.x == 15.0
-    assert r.y == 15.0
-
-
 def test_equivalency():
     assert LBWH(10, 10, 10, 10) == LRBT(10, 20, 10, 20) == XYWH(15, 15, 10, 10) == XYRR(15, 15, 5, 5) == A_RECT
 

--- a/tests/unit/rect/test_rect_instances.py
+++ b/tests/unit/rect/test_rect_instances.py
@@ -89,8 +89,19 @@ def test_views():
 class SubclassedRect(Rect):
     ...
 
+@pytest.fixture(params=(Rect, SubclassedRect))
+def rect_type(request):
+    return request.param
 
-@pytest.mark.parametrize("rect_type", (Rect, SubclassedRect))
-def test_repr_inheritance_safety(rect_type):
-     instance = rect_type(*(0 for _ in Rect._fields))
-     assert repr(instance).startswith(f"<{rect_type.__name__}")
+
+@pytest.fixture
+def rect_instance(rect_type):
+    return rect_type(*(0 for _ in Rect._fields))
+
+
+def test_repr_inheritance_safety(rect_type, rect_instance):
+     assert repr(rect_instance).startswith(f"{rect_type.__name__}")
+
+
+def test_str_inheritance_safety(rect_type, rect_instance):
+     assert str(rect_instance).startswith(f"<{rect_type.__name__}")

--- a/tests/unit/rect/test_rect_instances.py
+++ b/tests/unit/rect/test_rect_instances.py
@@ -1,3 +1,4 @@
+import pytest
 from pyglet.math import Vec2
 from arcade.types.rect import Rect, LBWH, LRBT, XYRR, XYWH
 
@@ -83,3 +84,13 @@ def test_views():
     assert A_RECT.xyrr == (15, 15,  5,  5)
     assert A_RECT.xywh == (15, 15, 10, 10)
     assert A_RECT.viewport == (10, 20, 10, 20)
+
+
+class SubclassedRect(Rect):
+    ...
+
+
+@pytest.mark.parametrize("rect_type", (Rect, SubclassedRect))
+def test_repr_inheritance_safety(rect_type):
+     instance = rect_type(*(0 for _ in Rect._fields))
+     assert repr(instance).startswith(f"<{rect_type.__name__}")

--- a/tests/unit/rect/test_rect_instances.py
+++ b/tests/unit/rect/test_rect_instances.py
@@ -1,3 +1,5 @@
+from typing import Callable, Any
+
 import pytest
 from pyglet.math import Vec2
 from arcade.types.rect import Rect, LBWH, LRBT, XYRR, XYWH
@@ -89,19 +91,29 @@ def test_views():
 class SubclassedRect(Rect):
     ...
 
-@pytest.fixture(params=(Rect, SubclassedRect))
-def rect_type(request):
-    return request.param
+
+ALL_ZEROES = tuple((0 for _ in Rect._fields))
 
 
-@pytest.fixture
-def rect_instance(rect_type):
-    return rect_type(*(0 for _ in Rect._fields))
+def _formats_correctly(
+        func: Callable[[Any], str],
+        starts_with_format: str,
+        instance: Any
+) -> bool:
+    """True if func(instance) starts w/ its class name as specified."""
+
+    class_name = instance.__class__.__name__
+    return func(instance).startswith(
+        starts_with_format.format(class_name=class_name))
 
 
-def test_repr_inheritance_safety(rect_type, rect_instance):
-     assert repr(rect_instance).startswith(f"{rect_type.__name__}")
+def test_repr():
+    params = (repr, "{class_name}")
+    assert _formats_correctly(*params, Rect(*ALL_ZEROES))
+    assert _formats_correctly(*params, SubclassedRect(*ALL_ZEROES))
 
 
-def test_str_inheritance_safety(rect_type, rect_instance):
-     assert str(rect_instance).startswith(f"<{rect_type.__name__}")
+def test_str_inheritance_safety():
+    params = (str, "<{class_name}")
+    assert _formats_correctly(*params, Rect(*ALL_ZEROES))
+    assert _formats_correctly(*params, SubclassedRect(*ALL_ZEROES))


### PR DESCRIPTION
* Split existing tests for `Rect`
* Add `Kwargtangle` tests
* Change `__repr__` behavior to output runnable code
* Do some `arcade.types` restructuring
* Add inheritance safety + tests for `__str__` and `__repr__`